### PR TITLE
add sort and distinct methods on ArrayUtils

### DIFF
--- a/.github/workflows/s3-visualizer.yml
+++ b/.github/workflows/s3-visualizer.yml
@@ -7,10 +7,6 @@ on:
       - Release
   workflow_dispatch:
     inputs:
-      tags-or-branch:
-        default: master
-        type: string
-        description: "Pick Tag of Branch to upload"
       environment:
         default: ENV
         type: environment
@@ -27,11 +23,10 @@ jobs:
         with:
           node-version: 18.x
       - name: Run test
-        run: npm ci && npm test
-      #- name: Move File Unique Directory
-      #  run: |
-      #    mkdir -p s3/co2visualizer/${{ github.ref_name }}
-      #    mv coverage/* s3/co2visualizer/${{ github.ref_name }}
+        run: |
+          npm ci && npm test
+          touch coverage/error.html
+          echo "<html><body> <h1 style='color: red'>Error - Something wrong</h1> </body></html>" > coverage/error.html
       - name: Upload Files to S3
         uses: shallwefootball/s3-upload-action@master
         id: S3
@@ -43,5 +38,4 @@ jobs:
           destination_dir: 'co2visualizer/${{ github.ref_name }}'
       - name: Display URL
         run: |
-          echo "${{ steps.S3.outputs.object_key }}"
-          echo "${{ secrets.VISUALIZER_URL }}/co2visualizer/${{ github.ref_name }}/index.html"
+          echo "${{ env.VISUALIZER_URL }}/${{ steps.S3.outputs.object_key }}/index.html"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # co2m.js
+
 ___
+
 ##### 🚦 Build Status
+
 ![co2m.js workflow](https://github.com/nivekalara237/co2mjs/actions/workflows/cicd-pipeline.yml/badge.svg?branch=master)
 
 ![co2m.js workflow](https://github.com/nivekalara237/co2mjs/actions/workflows/release.yml/badge.svg)
 ___
 
 ### The Common JS Library
+
 ___
 
 
-`✨Common JavaScript Utilities ✅` is a collection of reusable, well-tested, and easy-to-use utility functions designed to simplify everyday JavaScript programming tasks. This library provides a set of commonly needed functionalities, ranging from array manipulations and object operations to string processing and date handling. Whether you are working on a web application, Node.js project, or any other JavaScript-based project, these utilities can help you write cleaner and more efficient code by reducing the need to reinvent the wheel.
+`✨Common JavaScript Utilities ✅` is a collection of reusable, well-tested, and easy-to-use utility functions designed to
+simplify everyday JavaScript programming tasks. This library provides a set of commonly needed functionalities, ranging
+from array manipulations and object operations to string processing and date handling. Whether you are working on a web
+application, Node.js project, or any other JavaScript-based project, these utilities can help you write cleaner and more
+efficient code by reducing the need to reinvent the wheel.
 
 ❇️❇️ ___Key features include:___
 
@@ -19,45 +27,56 @@ ___
 3. __`String Manipulations`__ - Handy methods for formatting, trimming, splitting, and joining strings.
 4. __`Date Handling`__ - Utilities for parsing, formatting, and calculating date differences.
 5. __`Type Checking`__ - Functions to determine data types, including custom type checks.
-6. __`Math Utilities`__ - Methods for performing common mathematical operations like rounding, averaging, and finding the maximum/minimum values.
-7. __`Random Generation`__ - Utilities for generating secure random numbers, strings, and IDs. 
-8. __`Numeric Manipulations`__ - Functions to handle numerical operations, including conversions, rounding, and precision handling. 
+6. __`Math Utilities`__ - Methods for performing common mathematical operations like rounding, averaging, and finding
+   the maximum/minimum values.
+7. __`Random Generation`__ - Utilities for generating secure random numbers, strings, and IDs.
+8. __`Numeric Manipulations`__ - Functions to handle numerical operations, including conversions, rounding, and
+   precision handling.
 9. __`Boolean Operations`__ - Tools for simplifying logical expressions and boolean evaluations
-10. __`Throwable Utilities`__ - Functions to create and manage custom errors, with tools for enhanced error handling and debugging.
+10. __`Throwable Utilities`__ - Functions to create and manage custom errors, with tools for enhanced error handling and
+    debugging.
 11. __`Miscellaneous`__ - Other helpful utilities such as debounce, throttle, and random ID generation.
 
-This project is ideal for developers looking for a lightweight, dependency-free library to enhance their JavaScript coding experience. All utilities are optimized for performance and are designed to work seamlessly across different environments, including browsers and Node.js.
-
+This project is ideal for developers looking for a lightweight, dependency-free library to enhance their JavaScript
+coding experience. All utilities are optimized for performance and are designed to work seamlessly across different
+environments, including browsers and Node.js.
 
 ### 🚀 Installation
 
-You can easily install the Common JavaScript Utilities library via npm. Simply run the following command in your project directory:
+You can easily install the Common JavaScript Utilities library via npm. Simply run the following command in your project
+directory:
 
-```bash
+```sh
 npm install co2m.js
 ```
+
 Alternatively, if you're using Yarn, you can install it with:
 
-```bash
+```shell
 yarn add co2m.js
 ```
 
-Once installed, you can start using the utility functions in your JavaScript or TypeScript projects by importing the necessary modules:
+Once installed, you can start using the utility functions in your JavaScript or TypeScript projects by importing the
+necessary modules:
 
-```js
+```ts
 // Importing specific utilities
-import { ArrayUtils, StringUtils } from 'co2m.js';
+import {ArrayUtils, StringUtils} from 'co2m.js';
 
 // Using a utility function
-const sortedArray = ArrayUtils.sort([5, 2, 9, 1]);
+const sortedArray = ArrayUtils.sortInt([5, 2, 9, 1]);
 // ==> [1, 2, 5, 9]
+const distinctArray = ArrayUtils.distinct<number>([12, 2, 12, 9]);
+// ==> [12, 2, 9]
 const formattedString = StringUtils.trim('   Hello World!   ');
 // ==> 'Hello World!'
-const formattedString = StringUtils.leftPad("1", "0", 3);
+const padString = StringUtils.leftPad("1", "0", 3);
 // ==> '0001'
 ```
 
 ##### License
+
 This project is licensed under the Apache License 2.0.
 
-You are free to use, modify, and distribute this software in accordance with the terms of the license. For more details, please refer to the LICENSE file included in the repository.
+You are free to use, modify, and distribute this software in accordance with the terms of the license. For more details,
+please refer to the LICENSE file included in the repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "co2m.js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "co2m.js",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "co2m.js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/lib/utils/array.utils.ts
+++ b/src/lib/utils/array.utils.ts
@@ -1,4 +1,6 @@
 import { ObjectUtils } from "./object.utils";
+import { ThrowableUtils } from "./throwable.utils";
+import { compareInt } from "./sort/helper";
 
 export class ArrayUtils {
   public static setToArray = (set: Set<any> | any): any[] => {
@@ -8,7 +10,7 @@ export class ArrayUtils {
 
   public static groupBy = (
     array: any[] | any,
-    key: string,
+    key: string
   ): { [k: string]: any[] } => {
     if (
       ObjectUtils.isNullOrUndefined(array) ||
@@ -19,12 +21,12 @@ export class ArrayUtils {
     return array.reduce(
       (
         accumulator: { [x: string]: any },
-        items: { [x: string]: string | number },
+        items: { [x: string]: string | number }
       ) => (
         (accumulator[items[key]] = [...(accumulator[items[key]] || []), items]),
         accumulator
       ),
-      {},
+      {}
     );
   };
 
@@ -42,5 +44,95 @@ export class ArrayUtils {
     }
 
     return [value];
+  };
+
+  static sortInt = (array: number[], reverse?: boolean) => {
+    ThrowableUtils.requireNonNull(array, "array");
+    return array.sort((a, b) => (reverse ? b - a : a - b));
+  };
+
+  static sortString = (
+    array: string[],
+    config?: {
+      reverse?: boolean;
+      ignoreCase?: boolean;
+    }
+  ) => {
+    ThrowableUtils.requireNonNull(array, "array");
+    const sensitive = (s: string) => (config?.ignoreCase ? s.toLowerCase() : s);
+    return array.sort((a, b) =>
+      config?.reverse
+        ? sensitive(b).localeCompare(sensitive(a))
+        : sensitive(a).localeCompare(sensitive(b))
+    );
+  };
+
+  static sort = <T extends object>(
+    array: Array<T>,
+    key: string,
+    config?: { reverse?: boolean; ignoreCase?: boolean; strict?: boolean }
+  ) => {
+    ThrowableUtils.requireNonNull(array, "array");
+    ThrowableUtils.requireNonNull(key, "key");
+
+    if (
+      !Array.isArray(array) ||
+      (Array.of(...array).length > 0 && typeof array[0] !== "object")
+    ) {
+      ThrowableUtils.raise("Invalid Array of object type");
+    }
+
+    return array.sort((a: T, b: T) => {
+      if (config?.strict && typeof a[key] !== typeof b[key]) {
+        ThrowableUtils.raise(
+          `Incompatibility with the values of key provider: first arg type=${typeof a[key]} and second arg type=${typeof b[key]}`
+        );
+      }
+      if (
+        ["number", "bigint"].includes(typeof a[key]) &&
+        ["number", "bigint"].includes(typeof b[key])
+      ) {
+        const aNum: number | bigint = a[key];
+        const bNum: number | bigint = b[key];
+        return config?.reverse
+          ? compareInt(bNum, aNum)
+          : compareInt(aNum, bNum);
+      }
+
+      if (typeof a[key] === "string" && typeof b[key] === "string") {
+        return config?.reverse
+          ? b[key].localeCompare(a[key])
+          : a[key].localeCompare(b[key]);
+      }
+
+      ThrowableUtils.raise(
+        `Incompatibility with the values of key provider: first arg type=${typeof a[key]} and second arg type=${typeof b[key]}`
+      );
+    });
+  };
+
+  static distinct = <T>(array: T[], byKey?: string) => {
+    if (ObjectUtils.isNullOrUndefined(array)) {
+      ThrowableUtils.raise("The array must be defined");
+    }
+    if (array.length === 0) {
+      return [];
+    }
+
+    const distinct: T[] = [];
+
+    for (let i = 0; i < array.length; i++) {
+      const value = array[i];
+      if (byKey) {
+        if (distinct.findIndex((v) => v[byKey] === value[byKey]) > -1) {
+          continue;
+        }
+      } else {
+        if (distinct.indexOf(value) > -1) continue;
+      }
+      distinct.push(value);
+    }
+
+    return distinct;
   };
 }

--- a/src/lib/utils/cryptographically.ts
+++ b/src/lib/utils/cryptographically.ts
@@ -1,4 +1,5 @@
 import { ThrowableUtils } from "./throwable.utils";
+import { getRandomValues } from "node:crypto";
 
 export type TypedIntArray =
   | Int8Array
@@ -20,7 +21,7 @@ export const bytesToInteger = (bytes: TypedIntArray) => {
 
 export const random = (): number => {
   const randomUint32Values = new Uint32Array(1);
-  crypto.getRandomValues(randomUint32Values);
+  getRandomValues(randomUint32Values);
   const u32Max = 0xffffffff;
   return randomUint32Values[0]! / (u32Max + 1);
 };
@@ -32,14 +33,14 @@ export const random = (): number => {
 export const randomInteger = (max: number): number => {
   if (max < 0 || Number.MAX_SAFE_INTEGER < max) {
     ThrowableUtils.raise(
-      "Argument 'max' must be an integer greater than or equal to 0",
+      "Argument 'max' must be an integer greater than or equal to 0"
     );
   }
   const bitLength = (max - 1).toString(2).length;
   const shift = bitLength % 8;
   const bytes = new Uint8Array(Math.ceil(bitLength / 8));
 
-  crypto.getRandomValues(bytes);
+  getRandomValues(bytes);
 
   if (shift !== 0) {
     bytes[0] &= (1 << shift) - 1;
@@ -48,7 +49,7 @@ export const randomInteger = (max: number): number => {
   let result = bytesToInteger(bytes);
 
   while (result > max - 1) {
-    crypto.getRandomValues(bytes);
+    getRandomValues(bytes);
     if (shift !== 0) {
       bytes[0] &= (1 << shift) - 1;
     }

--- a/src/lib/utils/math/mix.utils.ts
+++ b/src/lib/utils/math/mix.utils.ts
@@ -1,0 +1,6 @@
+type Mix = number | bigint;
+class MixUtils {
+    static minus = (a: Mix, b: Mix ) => {
+
+    }
+}

--- a/src/lib/utils/math/mix.utils.ts
+++ b/src/lib/utils/math/mix.utils.ts
@@ -1,6 +1,0 @@
-type Mix = number | bigint;
-class MixUtils {
-    static minus = (a: Mix, b: Mix ) => {
-
-    }
-}

--- a/src/lib/utils/random.utils.ts
+++ b/src/lib/utils/random.utils.ts
@@ -1,6 +1,7 @@
 import { ThrowableUtils } from "./throwable.utils";
 import { BranchUtils } from "./branch.utils";
 import { random, randomInteger } from "./cryptographically";
+import { getRandomValues } from "node:crypto";
 
 export class RandomUtils {
   private static ALPHA_NUMERIC_CHARS =
@@ -30,7 +31,7 @@ export class RandomUtils {
       ThrowableUtils.raise("The min and max values can't be equal");
     }
     const dataView = new Uint8Array(1);
-    crypto.getRandomValues(dataView);
+    getRandomValues(dataView);
     const value = dataView.at(0);
     if (BranchUtils.betweenRangeNumber(value, min, max - 1)) {
       return value;

--- a/src/lib/utils/sort/comparable.ts
+++ b/src/lib/utils/sort/comparable.ts
@@ -1,0 +1,3 @@
+export interface Comparable<T> {
+    apply(a: T, b: T): -1 | 0 | 1
+}

--- a/src/lib/utils/sort/comparable.ts
+++ b/src/lib/utils/sort/comparable.ts
@@ -1,3 +1,4 @@
+/*eslint no-unused-vars: "off"*/
 export interface Comparable<T> {
-    apply(a: T, b: T): -1 | 0 | 1
+  apply(a: T, b: T): -1 | 0 | 1;
 }

--- a/src/lib/utils/sort/comparator.ts
+++ b/src/lib/utils/sort/comparator.ts
@@ -1,0 +1,6 @@
+import {Comparable} from "./comparable";
+
+export class Comparator {
+
+    of = (func: Comparable<any>) => {}
+}

--- a/src/lib/utils/sort/comparator.ts
+++ b/src/lib/utils/sort/comparator.ts
@@ -1,6 +1,8 @@
-import {Comparable} from "./comparable";
+import { Comparable } from "./comparable";
+import { compareInt } from "./helper";
 
-export class Comparator {
-
-    of = (func: Comparable<any>) => {}
+export class Comparator implements Comparable<number> {
+  apply(a: number, b: number): -1 | 0 | 1 {
+    return compareInt(a, b);
+  }
 }

--- a/src/lib/utils/sort/helper.ts
+++ b/src/lib/utils/sort/helper.ts
@@ -1,0 +1,1 @@
+export const compareInt = (a: number | bigint, b: number | bigint): -1 | 0 | 1 => a > b ? 1 : (a === b ? 0 : -1);

--- a/src/tests/utils/array.utils.spec.ts
+++ b/src/tests/utils/array.utils.spec.ts
@@ -83,4 +83,270 @@ describe("Tests array utilities", () => {
       ]);
     });
   });
+
+  describe("Sort Number", () => {
+    it("should provide undefined array", () => {
+      expect(() => ArrayUtils.sortInt(null)).toThrow(
+        "The array must not be a null value"
+      );
+    });
+    it("should sort array provided", () => {
+      expect(ArrayUtils.sortInt([2, 3, 0, 1, 8, 1])).toEqual([
+        0, 1, 1, 2, 3, 8,
+      ]);
+    });
+    it("should reverse sort array provided", () => {
+      expect(ArrayUtils.sortInt([2, 3, 0, 1, 8, 1], true)).toEqual([
+        8, 3, 2, 1, 1, 0,
+      ]);
+    });
+  });
+
+  describe("Sort String", () => {
+    it("should provide undefined array", () => {
+      expect(() => ArrayUtils.sortString(null)).toThrow(
+        "The array must not be a null value"
+      );
+    });
+    it("should sort array provided", () => {
+      expect(ArrayUtils.sortString(["a", "b", "z", "d", "8", "a"])).toEqual([
+        "8",
+        "a",
+        "a",
+        "b",
+        "d",
+        "z",
+      ]);
+    });
+    it("should reverse sort array provided", () => {
+      expect(
+        ArrayUtils.sortString(["a", "b", "z", "d", "8", "a"], { reverse: true })
+      ).toEqual(["z", "d", "b", "a", "a", "8"]);
+    });
+    it("should reverse and ignore case sort array provided", () => {
+      expect(
+        ArrayUtils.sortString(["a", "b", "Z", "d", "8", "A"], {
+          reverse: true,
+          ignoreCase: true,
+        })
+      ).toEqual(["Z", "d", "b", "a", "A", "8"]);
+    });
+    it("should ignore case sort array provided", () => {
+      expect(
+        ArrayUtils.sortString(["a", "b", "Z", "d", "8", "A"], {
+          reverse: true,
+          ignoreCase: true,
+        })
+      ).toEqual(["Z", "d", "b", "a", "A", "8"]);
+    });
+  });
+
+  describe("Sort Object", () => {
+    it("should sort null array", () => {
+      expect(() => ArrayUtils.sort<{ id: string }>(null, "id")).toThrow(
+        "The array must not be a null value"
+      );
+    });
+    it("should sort undefined array by key", () => {
+      expect(() => ArrayUtils.sort<{ id: string }>(undefined, "id")).toThrow(
+        "Invalid Array of object type"
+      );
+    });
+    it("should sort non object array by key", () => {
+      expect(() => ArrayUtils.sort<any>([2, "id"], "id")).toThrow(
+        "Invalid Array of object type"
+      );
+    });
+    it("should sort non array of objects by key '(2)'", () => {
+      expect(() => ArrayUtils.sort<any>([], "id")).not.toThrow();
+    });
+    it("should sort array of objects by key - (integer) DESC", () => {
+      expect(
+        ArrayUtils.sort<{ id: number; name: string }>(
+          [
+            {
+              id: 3,
+              name: "John",
+            },
+            {
+              id: 1,
+              name: "Joe",
+            },
+            {
+              id: 2,
+              name: "Alex",
+            },
+          ],
+          "id"
+        )
+      ).toEqual([
+        {
+          id: 1,
+          name: "Joe",
+        },
+        {
+          id: 2,
+          name: "Alex",
+        },
+        {
+          id: 3,
+          name: "John",
+        },
+      ]);
+    });
+    it("should sort array of objects by key - (integer) ASC", () => {
+      expect(
+        ArrayUtils.sort<{ id: number; name: string }>(
+          [
+            {
+              id: 3,
+              name: "John",
+            },
+            {
+              id: 1,
+              name: "Joe",
+            },
+            {
+              id: 2,
+              name: "Alex",
+            },
+          ],
+          "id",
+          {
+            reverse: true,
+          }
+        )
+      ).toEqual([
+        {
+          id: 3,
+          name: "John",
+        },
+        {
+          id: 2,
+          name: "Alex",
+        },
+        {
+          id: 1,
+          name: "Joe",
+        },
+      ]);
+    });
+    it("should sort array of objects by key - (string) DESC and ignore case", () => {
+      expect(
+        ArrayUtils.sort<{ id: number; name: string }>(
+          [
+            {
+              id: 3,
+              name: "JoHn",
+            },
+            {
+              id: 1,
+              name: "Joe",
+            },
+            {
+              id: 2,
+              name: "Alex",
+            },
+          ],
+          "name",
+          {
+            reverse: false,
+            ignoreCase: true,
+          }
+        )
+      ).toEqual([
+        {
+          id: 2,
+          name: "Alex",
+        },
+        {
+          id: 1,
+          name: "Joe",
+        },
+        {
+          id: 3,
+          name: "JoHn",
+        },
+      ]);
+    });
+
+    it("should throw error due to strict mode", () => {
+      expect(() =>
+        ArrayUtils.sort<{ id: number; name: any }>(
+          [
+            {
+              id: 3,
+              name: "JoHn",
+            },
+            {
+              id: 1,
+              name: 3,
+            },
+          ],
+          "name",
+          {
+            reverse: false,
+            ignoreCase: true,
+            strict: true,
+          }
+        )
+      ).toThrow(
+        "Incompatibility with the values of key provider: first arg type=number and second arg type=string"
+      );
+    });
+  });
+
+  describe("Distinct", () => {
+    it("should throw error", () => {
+      expect(() => ArrayUtils.distinct<number>(null)).toThrow(
+        "The array must be defined"
+      );
+      expect(() => ArrayUtils.distinct<number>(undefined)).toThrow(
+        "The array must be defined"
+      );
+    });
+    it("should distinct array items", () => {
+      expect(ArrayUtils.distinct<number>([2, 3, 2, 5])).toEqual([2, 3, 5]);
+    });
+    it("should distinct empty array", () => {
+      expect(ArrayUtils.distinct<number>([])).toEqual([]);
+    });
+    it("should distinct array items - string", () => {
+      expect(ArrayUtils.distinct<string>(["2", "3", "2", "5"])).toEqual([
+        "2",
+        "3",
+        "5",
+      ]);
+    });
+    it("should distinct array items - object", () => {
+      expect(
+        ArrayUtils.distinct<{ id: number; name: string }>(
+          [
+            {
+              id: 2,
+              name: "joe",
+            },
+            {
+              id: 1,
+              name: "joe",
+            },
+            {
+              id: 3,
+              name: "john",
+            },
+          ],
+          "name"
+        )
+      ).toEqual([
+        {
+          id: 2,
+          name: "joe",
+        },
+        {
+          id: 3,
+          name: "john",
+        },
+      ]);
+    });
+  });
 });

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,9 +1,10 @@
 import esbuild from "esbuild";
-import {replaceTextInFile, run} from "./utils.js";
+import { replaceTextInFile, run } from "./utils.js";
 import copy from "esbuild-plugin-copy";
 import writeFilePlugin from "esbuild-plugin-write-file";
-import _package from "../package.json" with { type: "json" }
+import _package from "../package.json" with { type: "json" };
 import textReplace from "esbuild-plugin-text-replace";
+
 Promise.all([
   run("tsc -p tsconfig.build.json"),
   replaceTextInFile("./dist/index.d.ts", '"index"', '"co2m.js"'),
@@ -26,36 +27,34 @@ Promise.all([
     platform: "node",
     outfile: "./dist/index.cjs",
     plugins: [
-        copy({
-          resolveFrom: "cwd",
-          // dryRun: true,
-          assets: [
-            {
-              from: ["./package.json"],
-              to: ["./dist/package.json"]
-            },
-            {
-              from: ["./LICENSE"],
-              to: ["./dist"]
-            },
-            {
-              from: ["./README.md"],
-              to: ["./dist/README.md"]
-            }
-          ]
-        }),
-        writeFilePlugin({
-          after: {
-            "./dist/version.txt" : `${_package.version}`
-          }
-        }),
-        textReplace({
-          include: /dist\/index\.d\.ts$/,
-          pattern: [
-              ['index', 'co2m.js']
-          ]
-        })
-    ]
+      copy({
+        resolveFrom: "cwd",
+        // dryRun: true,
+        assets: [
+          {
+            from: ["./package.json"],
+            to: ["./dist/package.json"],
+          },
+          {
+            from: ["./LICENSE"],
+            to: ["./dist"],
+          },
+          {
+            from: ["./README.md"],
+            to: ["./dist/README.md"],
+          },
+        ],
+      }),
+      writeFilePlugin({
+        after: {
+          "./dist/version.txt": `${_package.version}`,
+        },
+      }),
+      textReplace({
+        include: /dist\/index\.d\.ts$/,
+        pattern: [["index", "co2m.js"]],
+      }),
+    ],
   }),
 
   // bundle for browser
@@ -65,7 +64,6 @@ Promise.all([
     bundle: true,
     minify: true,
     outfile: "./dist/index.min.js",
-    platform: "browser",
+    platform: "node",
   }),
-
 ]).then();


### PR DESCRIPTION
ArrayUtils
- `sortInt` - to sort array of type __number__ and __bigint__
- `sortString`- to sort array of type string
- `sort<T>`- to sort array of type object, need to specify key object
- Test covering
- update random utils by removing `crypto` global variable and importing `node:crypto` instead